### PR TITLE
20191002 abstract unix socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(netrom nrcmd.c nrsock.c nr4user.c nr4timer.c nr4.c nr4subr.c nr4hdr.
 add_library(ppp asy.c asy_unix.c ppp.c pppcmd.c pppfsm.c ppplcp.c ppppap.c pppipcp.c pppdump.c slhc.c slhcdump.c slip.c sppp.c)
 add_library(netinet ftpsubr.c sockcmd.c sockuser.c locsock.c socket.c sockutil.c iface.c timer.c ttydriv.c cmdparse.c mbuf.c misc.c pathname.c files.c kernel.c ksubr_unix.c wildmat.c devparam.c stdio.c ahdlc.c crc.c md5c.c errno.c errlst.c getopt.c)
 add_library(dump trace.c enetdump.c kissdump.c ax25dump.c arpdump.c nrdump.c ipdump.c icmpdump.c udpdump.c tcpdump.c ripdump.c)
-add_library(unix ksubr_unix.c timer_unix.c display_crs.c unix.c dirutil_unix.c enet.c)
+add_library(unix ksubr_unix.c timer_unix.c display_crs.c unix.c dirutil_unix.c enet.c unix_socket.c)
 
 if (HAVE_NET_IF_TAP_H)
   add_library(tap tapdrvr.c)

--- a/asy_unix.c
+++ b/asy_unix.c
@@ -273,15 +273,16 @@ void *p;
 static void
 pasy(struct asy *asyp)
 {
+	struct unix_socket_stats stats;
 	int mcr;
 
 	printf("%s:",asyp->iface->name);
-	if(asyp->socket_entry->trigchar != -1)
-		kprintf(" [trigger 0x%02x]",asyp->socket_entry->trigchar);
-	if(asyp->socket_entry->cts)
+	if(unix_socket_get_trigchar(asyp->socket_entry) != -1)
+		kprintf(" [trigger 0x%02x]",unix_socket_get_trigchar(asyp->socket_entry));
+	if(unix_socket_flowcontrol_cts(asyp->socket_entry))
 		kprintf(" [cts flow control]");
 
-	kprintf(" %lu bps\n",asyp->socket_entry->speed);
+	kprintf(" %lu bps\n",unix_socket_get_speed(asyp->socket_entry));
 
 	if (unix_socket_is_real_tty(asyp->socket_entry)) {
 		if (unix_socket_modem_bits(asyp->socket_entry, 0, 0, &mcr) != 0)
@@ -298,12 +299,12 @@ pasy(struct asy *asyp)
 	} else {
 		kprintf(" TCP socket, no control bits.\n");
 	}
-	
-	kprintf(" RX: chars %lu", asyp->socket_entry->rxchar);
-	kprintf(" sw over %lu sw hi %u\n",asyp->socket_entry->fifo.overrun,asyp->socket_entry->fifo.hiwat);
+	(void) unix_socket_get_stats(asyp->socket_entry, &stats);
 
-	kprintf(" TX: chars %lu %s\n",
-	 asyp->socket_entry->txchar, asyp->socket_entry->dma.busy ? " BUSY" : "");
+	kprintf(" RX: chars %lu", stats.rxchar);
+	kprintf(" sw over %lu sw hi %u\n", stats.fifo_overrun, stats.fifo_hiwat);
+	kprintf(" TX: chars %lu %s\n", stats.txchar,
+	 unix_socket_tx_dma_busy(asyp->socket_entry) ? " BUSY" : "");
 }
 
 /* Send a message on the specified serial line */

--- a/asy_unix.c
+++ b/asy_unix.c
@@ -124,7 +124,7 @@ long bps
 	if(bps == 0)
 		return -1;
 
-	if (asyp->socket_entry->is_real_tty) {
+	if (unix_socket_is_real_tty(asyp->socket_entry)) {
 		if (tcgetattr(asyp->socket_entry->ttyfd, &tc) != 0)
 			return -1;
 		if (cfsetspeed(&tc, bps) != 0)
@@ -158,7 +158,7 @@ int32 val
 	case PARAM_DTR:
 		setbits = (set && val) ? TIOCM_DTR : 0;
 		clearbits = (set && !val) ? 0 : TIOCM_DTR;
-		if (ap->socket_entry->is_real_tty) {
+		if (unix_socket_is_real_tty(ap->socket_entry)) {
 			unix_socket_modem_bits(ap->socket_entry,setbits,clearbits,&bits);
 			return (bits & TIOCM_DTR) ? TRUE : FALSE;
 		}
@@ -166,17 +166,17 @@ int32 val
 	case PARAM_RTS:
 		setbits = (set && val) ? TIOCM_RTS : 0;
 		clearbits = (set && !val) ? 0 : TIOCM_RTS;
-		if (ap->socket_entry->is_real_tty) {
+		if (unix_socket_is_real_tty(ap->socket_entry)) {
 			unix_socket_modem_bits(ap->socket_entry,setbits,clearbits,&bits);
 			return (bits & TIOCM_RTS) ? TRUE : FALSE;
 		}
 		return TRUE;
 	case PARAM_DOWN:
-		if (ap->socket_entry->is_real_tty)
+		if (unix_socket_is_real_tty(ap->socket_entry))
 			unix_socket_modem_bits(ap->socket_entry,0,TIOCM_RTS|TIOCM_DTR,NULL);
 		return FALSE;
 	case PARAM_UP:
-		if (ap->socket_entry->is_real_tty)
+		if (unix_socket_is_real_tty(ap->socket_entry))
 			unix_socket_modem_bits(ap->socket_entry,TIOCM_RTS|TIOCM_DTR,0,NULL);
 		return TRUE;
 	}
@@ -327,7 +327,7 @@ pasy(struct asy *asyp)
 
 	kprintf(" %lu bps\n",asyp->socket_entry->speed);
 
-	if (asyp->socket_entry->is_real_tty) {
+	if (unix_socket_is_real_tty(asyp->socket_entry)) {
 		if (unix_socket_modem_bits(asyp->socket_entry, 0, 0, &mcr) != 0)
 			kprintf("modem bits error: %s\n", strerror(errno));
 			return;

--- a/asy_unix.c
+++ b/asy_unix.c
@@ -46,16 +46,13 @@
 #include "asy_unix.h"
 #include "nosunix.h"
 
+#include "unix_socket.h"
+
 struct asy Asy[ASY_MAX];
 
-static int asy_open_dev(const char *path, int cts, long speed);
-static int asy_open_socket(const char *spec);
 static int asy_modem_bits(int fd, int setbits, int clearbits, int *readbits);
 static void pasy(struct asy *asyp);
-static void *asy_io_read_proc(void *asyp);
-static void *asy_io_write_proc(void *asyp);
 static void asy_tx(int dummy0, void *app, void *dummy1);
-static int asy_write_int(struct asy *asyp, const void *buf,unsigned short cnt);
 
 /* Initialize asynch port "dev" */
 int
@@ -68,9 +65,7 @@ int trigchar,
 long speed,
 int cts		/* Use CTS flow control */
 ){
-	int ttyfd;
 	struct asy *ap;
-	void *dummy;
 	char *procname;
 
 	if(dev >= ASY_MAX)
@@ -78,67 +73,14 @@ int cts		/* Use CTS flow control */
 
 	ap = &Asy[dev];
 
-	if (strchr(path, ':') == NULL) {
-		if ((ttyfd = asy_open_dev(path, cts, speed)) == -1) {
-			goto CantOpenDevice;
-		}
-		ap->is_real_tty = 1;
-	} else {
-		if ((ttyfd = asy_open_socket(path)) == -1) {
-			goto CantOpenDevice;
-		}
-		ap->is_real_tty = 0;
+	ap->socket_entry = unix_socket_create(path, bufsize, trigchar, speed, cts);
+	if (ap->socket_entry == NULL) {
+		kprintf("can't allocate/connect a unix socket\n");
+		goto error;
 	}
 
-	/* Set up receiver FIFO */
-	if ((ap->fifo.buf = malloc(bufsize)) == NULL) {
-		kprintf("Can't allocate read ring buffer.\n");
-		goto CantAllocReadBuf;
-	}
-	ap->fifo.bufsize = bufsize;
-	ap->fifo.wp = ap->fifo.buf;
-	ap->fifo.rp = ap->fifo.buf;
-	ap->fifo.cnt = 0;
-	ap->fifo.hiwat = 0;
-	ap->fifo.overrun = 0;
-
-	if (pthread_mutex_init(&ap->read_lock, NULL) != 0) {
-		kprintf("Can't init read lock: %s\n", strerror(errno));
-		goto CantInitReadLock;
-	}
-	if (pthread_mutex_init(&ap->write_lock, NULL) != 0) {
-		kprintf("Can't init write lock: %s\n", strerror(errno));
-		goto CantInitWriteLock;
-	}
-	if (pthread_cond_init(&ap->write_ready, NULL) != 0) {
-		kprintf("Can't init write cond: %s\n", strerror(errno));
-		goto CantInitWriteCond;
-	}
-	pthread_mutex_lock(&ap->read_lock);
-	pthread_mutex_lock(&ap->write_lock);
-	if (pthread_create(&ap->read_thread, NULL, asy_io_read_proc, ap) != 0){
-		kprintf("Can't start read thread: %s\n", strerror(errno));
-		goto CantStartReadThread;
-	}
-	if (pthread_create(&ap->write_thread, NULL, asy_io_write_proc, ap)!=0){
-		kprintf("Can't start write thread: %s\n", strerror(errno));
-		goto CantStartWriteThread;
-	}
-
-	ap->ttyfd = ttyfd;
 	ap->iface = ifp;
-	ap->trigchar = trigchar;
-	ap->cts = cts;
-	ap->speed = speed;
-	ap->dma.data = NULL;
-	ap->dma.cnt = 0;
-	ap->dma.busy = 0;
-	ap->write_exit = 0;
 	ap->txq = NULL;
-
-	/* drop read and write locks, which will start I/O */
-	pthread_mutex_unlock(&ap->read_lock);
-	pthread_mutex_unlock(&ap->write_lock);
 
 	/* Spawn the transmit deque process */
 	procname = if_name(ifp, " asytx");
@@ -146,27 +88,15 @@ int cts		/* Use CTS flow control */
 	free(procname);
 	if (ap->txproc == NULL) {
 		kprintf("Can't start asy tx process.\n");
-		goto CantStartTxProc;
+		goto error;
 	}
 
-
 	return 0;
-
-CantStartTxProc:
-CantStartWriteThread:
-	pthread_cancel(ap->read_thread);
-	pthread_join(ap->read_thread, &dummy);
-CantStartReadThread:
-	pthread_cond_destroy(&ap->write_ready);
-CantInitWriteCond:
-	pthread_mutex_destroy(&ap->write_lock);
-CantInitWriteLock:
-	pthread_mutex_destroy(&ap->read_lock);
-CantInitReadLock:
-	free(ap->fifo.buf);
-	ap->fifo.buf = NULL;
-CantAllocReadBuf:
-CantOpenDevice:
+error:
+	if (ap->socket_entry != NULL) {
+		unix_socket_shutdown(ap->socket_entry);
+		ap->socket_entry = NULL;
+	}
 	return -1;
 }
 
@@ -195,16 +125,16 @@ long bps
 	if(bps == 0)
 		return -1;
 
-	if (asyp->is_real_tty) {
-		if (tcgetattr(asyp->ttyfd, &tc) != 0)
+	if (asyp->socket_entry->is_real_tty) {
+		if (tcgetattr(asyp->socket_entry->ttyfd, &tc) != 0)
 			return -1;
 		if (cfsetspeed(&tc, bps) != 0)
 			return -1;
-		if (tcsetattr(asyp->ttyfd, TCSAFLUSH, &tc) != 0)
+		if (tcsetattr(asyp->socket_entry->ttyfd, TCSAFLUSH, &tc) != 0)
 			return -1;
 	}
 
-	asyp->speed = bps;
+	asyp->socket_entry->speed = bps;
 
 	return 0;
 }
@@ -225,30 +155,30 @@ int32 val
 	case PARAM_SPEED:
 		if(set)
 			asy_speed(ifp->dev,val);
-		return ap->speed;
+		return ap->socket_entry->speed;
 	case PARAM_DTR:
 		setbits = (set && val) ? TIOCM_DTR : 0;
 		clearbits = (set && !val) ? 0 : TIOCM_DTR;
-		if (ap->is_real_tty) {
-			asy_modem_bits(ap->ttyfd,setbits,clearbits,&bits);
+		if (ap->socket_entry->is_real_tty) {
+			asy_modem_bits(ap->socket_entry->ttyfd,setbits,clearbits,&bits);
 			return (bits & TIOCM_DTR) ? TRUE : FALSE;
 		}
 		return TRUE;
 	case PARAM_RTS:
 		setbits = (set && val) ? TIOCM_RTS : 0;
 		clearbits = (set && !val) ? 0 : TIOCM_RTS;
-		if (ap->is_real_tty) {
-			asy_modem_bits(ap->ttyfd,setbits,clearbits,&bits);
+		if (ap->socket_entry->is_real_tty) {
+			asy_modem_bits(ap->socket_entry->ttyfd,setbits,clearbits,&bits);
 			return (bits & TIOCM_RTS) ? TRUE : FALSE;
 		}
 		return TRUE;
 	case PARAM_DOWN:
-		if (ap->is_real_tty)
-			asy_modem_bits(ap->ttyfd,0,TIOCM_RTS|TIOCM_DTR,NULL);
+		if (ap->socket_entry->is_real_tty)
+			asy_modem_bits(ap->socket_entry->ttyfd,0,TIOCM_RTS|TIOCM_DTR,NULL);
 		return FALSE;
 	case PARAM_UP:
-		if (ap->is_real_tty)
-			asy_modem_bits(ap->ttyfd,TIOCM_RTS|TIOCM_DTR,0,NULL);
+		if (ap->socket_entry->is_real_tty)
+			asy_modem_bits(ap->socket_entry->ttyfd,TIOCM_RTS|TIOCM_DTR,0,NULL);
 		return TRUE;
 	}
 	return -1;
@@ -302,6 +232,18 @@ asy_close(int dev)
 	return 0;
 }
 
+int
+asy_read(int dev, void *buf, unsigned short cnt)
+{
+	struct asy *asyp;
+
+	if(dev < 0 || dev >= ASY_MAX)
+		return -1;
+	asyp = &Asy[dev];
+
+	return unix_socket_read(asyp->socket_entry, buf, cnt);
+}
+
 /* Send a buffer on the serial transmitter and wait for completion */
 int
 asy_write(
@@ -315,48 +257,7 @@ unsigned short cnt
 		return -1;
 	asyp = &Asy[dev];
 
-	return asy_write_int(asyp, buf, cnt);
-}
-
-static int
-asy_write_int(struct asy *asyp, const void *buf, unsigned short cnt)
-{
-	int tmp, i_state;
-	struct iface *ifp;
-	struct dma *dp;
-
-	if((ifp = asyp->iface) == NULL)
-		return -1;
-
-	dp = &asyp->dma;
-
-	i_state = disable();
-	if(dp->busy) {
-		restore(i_state);
-		return -1;	/* Already busy in another process */
-	}
-
-	pthread_mutex_lock(&asyp->write_lock);
-
-	dp->data = (uint8 *)buf;
-	dp->cnt = cnt;
-	dp->busy = 1;
-
-	pthread_cond_signal(&asyp->write_ready);
-	pthread_mutex_unlock(&asyp->write_lock);
-	restore(i_state);
-
-	/* Wait for completion */
-	for(;;){
-		i_state = disable();
-		tmp = dp->busy;
-		restore(i_state);
-		if(tmp == 0)
-			break;
-		kwait(&asyp->dma);
-	}
-	ifp->lastsent = secclock();
-	return cnt;
+	return unix_socket_write(asyp->socket_entry, buf, cnt);
 }
 
 /* Blocking read from asynch line
@@ -365,10 +266,15 @@ asy_write_int(struct asy *asyp, const void *buf, unsigned short cnt)
 int
 get_asy(int dev)
 {
+	struct asy *asyp;
 	uint8 c;
 	int tmp;
 
-	if((tmp = asy_read(dev,&c,1)) == 1)
+	if(dev < 0 || dev >= ASY_MAX)
+		return -1;
+	asyp = &Asy[dev];
+
+	if((tmp = unix_socket_read(asyp->socket_entry, &c, 1)) == 1)
 		return c;
 	else
 		return tmp;
@@ -415,15 +321,15 @@ pasy(struct asy *asyp)
 	int mcr;
 
 	printf("%s:",asyp->iface->name);
-	if(asyp->trigchar != -1)
-		kprintf(" [trigger 0x%02x]",asyp->trigchar);
-	if(asyp->cts)
+	if(asyp->socket_entry->trigchar != -1)
+		kprintf(" [trigger 0x%02x]",asyp->socket_entry->trigchar);
+	if(asyp->socket_entry->cts)
 		kprintf(" [cts flow control]");
 
-	kprintf(" %lu bps\n",asyp->speed);
+	kprintf(" %lu bps\n",asyp->socket_entry->speed);
 
-	if (asyp->is_real_tty) {
-		if (asy_modem_bits(asyp->ttyfd, 0, 0, &mcr) != 0)
+	if (asyp->socket_entry->is_real_tty) {
+		if (asy_modem_bits(asyp->socket_entry->ttyfd, 0, 0, &mcr) != 0)
 			kprintf("modem bits error: %s\n", strerror(errno));
 			return;
 
@@ -438,12 +344,11 @@ pasy(struct asy *asyp)
 		kprintf(" TCP socket, no control bits.\n");
 	}
 	
-	kprintf(" RX: chars %lu", asyp->rxchar);
-	kprintf(" sw over %lu sw hi %u\n",asyp->fifo.overrun,asyp->fifo.hiwat);
-	asyp->fifo.hiwat = 0;
+	kprintf(" RX: chars %lu", asyp->socket_entry->rxchar);
+	kprintf(" sw over %lu sw hi %u\n",asyp->socket_entry->fifo.overrun,asyp->socket_entry->fifo.hiwat);
 
 	kprintf(" TX: chars %lu %s\n",
-	 asyp->txchar, asyp->dma.busy ? " BUSY" : "");
+	 asyp->socket_entry->txchar, asyp->socket_entry->dma.busy ? " BUSY" : "");
 }
 
 /* Send a message on the specified serial line */
@@ -462,173 +367,6 @@ struct mbuf **bpp;
 	return 0;
 }
 
-int
-asy_read(
-int dev,
-void *buf,
-unsigned short cnt
-)
-{
-	int tmp, i_state;
-	struct fifo *fp;
-	uint8 *obp;
-
-	if (cnt == 0)
-		return 0;
-
-	if (dev < 0 || dev >= ASY_MAX) {
-		kerrno = kEINVAL;
-		return -1;
-	}
-
-	fp = &Asy[dev].fifo;
-
-	for (;;) {
-		i_state = disable();
-		tmp = fp->cnt;
-		if (tmp != 0)
-			break;
-		restore(i_state);
-		if ((kerrno = kwait(fp)) != 0)
-			return -1;
-	}
-
-	obp = (uint8 *)buf;
-
-	if (cnt > tmp)
-		cnt = tmp;	/* Limit to data on hand */
-	fp->cnt -= cnt;
-	for (tmp = cnt; tmp > 0; tmp--) {
-		*obp++ = *fp->rp++;
-		if (fp->rp >= &fp->buf[fp->bufsize])
-			fp->rp = fp->buf;
-	}
-	restore(i_state);
-
-	return cnt;
-}
-
-static int
-asy_open_dev(const char *path, int cts, long speed)
-{
-	int ttyfd;
-	struct termios tc;
-
-	if ((ttyfd = open(path, O_RDWR)) == -1) {
-		kprintf("Can't open '%s': %s\n",path,strerror(errno));
-		goto CantOpenDevice;
-	}
-	if (tcgetattr(ttyfd, &tc) != 0) {
-		kprintf("Can't get terminal attributes: %s\n", strerror(errno));
-		goto CantFetchTc;
-	}
-	cfmakeraw(&tc);
-	tc.c_cflag = CS8|CREAD|CLOCAL;
-	if (cts)
-		tc.c_cflag |= CRTSCTS;
-	if (cfsetspeed(&tc, speed) != 0) {
-		kprintf("Can't set baud rate: %s\n", strerror(errno));
-		goto InvalidSpeed;
-	}
-	if (tcsetattr(ttyfd, TCSANOW, &tc) != 0) {
-		kprintf("Can't set terminal attributes: %s\n", strerror(errno));
-		goto CantSetTc;
-	}
-
-	return ttyfd;
-
-CantSetTc:
-InvalidSpeed:
-CantFetchTc:
-	close(ttyfd);
-CantOpenDevice:
-	return -1;
-}
-
-static int
-asy_open_socket(const char *spec)
-{
-	char *hostname, *service;
-	const char *sep;
-	struct addrinfo hints, *res0, *res;
-	int fd, error;
-	
-	sep = (const char *) strrchr(spec, ':');
-	if (sep == NULL) {
-		kprintf("Host specification missing port\n");
-		goto BadChar;
-	}
-
-	service = strdup(sep+1);
-	if (service == NULL) {
-		kprintf("Out of memory.\n");
-		goto BadServiceAlloc;
-	}
-
-	hostname = (char *) malloc(sep - spec + 1);
-	if (hostname == NULL) {
-		kprintf("Out of memory.\n");
-		goto BadHostnameAlloc;
-	}
-
-	memcpy(hostname, spec, sep - spec);
-	hostname[sep - spec] = '\0';
-
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags =
-		AI_ADDRCONFIG | /* Use IPv4/IPv6 depending on availability */
-		AI_NUMERICSERV; /* Port should be a number */
-	hints.ai_canonname = NULL;
-	hints.ai_next = NULL;
-
-	error = getaddrinfo(hostname, service, &hints, &res0);
-	if (error != 0) {
-		kprintf("getaddrinfo() failure: %s\n", gai_strerror(error));
-		goto GetAddrInfoFailed;
-	}
-
-	/* Try each provided address in turn */
-
-	for (res = res0; res != NULL; res = res->ai_next) {
-		fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-		if (fd == -1) {
-			kprintf("socket() failed.\n");
-			goto SocketFailed;
-		}
-
-		error = connect(fd, res->ai_addr, res->ai_addrlen);
-		if (error >= 0)
-			break;
-
-		close(fd);
-	}
-
-	if (error < 0) {
-		kprintf("connect() failed: %s\n", strerror(errno));
-		goto ConnectFailed;
-	}
-
-	freeaddrinfo(res);
-	free(hostname);
-	free(service);
-
-	return fd;
-
-ConnectFailed:
-	close(fd);
-SocketFailed:
-	freeaddrinfo(res);
-GetAddrInfoFailed:
-	free(hostname);
-BadHostnameAlloc:
-	free(service);
-BadServiceAlloc:
-BadChar:
-	return -1;
-}
-
 static int
 asy_modem_bits(int fd, int setbits, int clearbits, int *readbits)
 {
@@ -639,106 +377,6 @@ asy_modem_bits(int fd, int setbits, int clearbits, int *readbits)
 	if (readbits != NULL && ioctl(fd, TIOCMGET, readbits) != 0)
 		return -1;
 	return 0;
-}
-
-static void *
-asy_io_read_proc(void *asyp)
-{
-	struct asy *ap = asyp;
-	ssize_t cnt, tmp;
-	uint8 buf[1024], *ibp;
-	struct fifo *fp;
-	int sig;
-
-	/* Wait until we are allowed to proceed */
-	pthread_mutex_lock(&ap->read_lock);
-
-	/* Go ahead and drop the read lock now that we've started */
-	pthread_mutex_unlock(&ap->read_lock);
-
-	fp = &ap->fifo;
-
-	for (;;) {
-		cnt = read(ap->ttyfd, buf, sizeof(buf));
-		if (cnt == -1)
-			break;
-
-		interrupt_enter();
-
-		/* Search read data for interesting characters if asked */
-		sig = ap->trigchar == -1 || memchr(buf, ap->trigchar, cnt);
-
-		/* Compute room left in FIFO */
-		tmp = fp->bufsize - fp->cnt;
-		if (cnt > tmp) {
-			/* Not enough room in FIFO */
-			fp->overrun += cnt - tmp;
-			cnt = tmp;
-		}
-
-		/* Update FIFO room */
-		fp->cnt += cnt;
-
-		/* Copy read data into FIFO */
-		ibp = buf;
-		for (tmp = cnt; tmp > 0; tmp--) {
-			*(fp->wp++) = *ibp++;
-			if (fp->wp >= &fp->buf[fp->bufsize])
-				fp->wp = fp->buf;
-		}
-
-		/* Update statistics */
-		ap->rxchar += cnt;
-		if (fp->cnt > fp->hiwat)
-			fp->hiwat = fp->cnt;
-
-		/* Wakeup any sleepers if an interesting event has happened */
-		if (sig)
-			ksignal(fp, 1);
-
-		interrupt_leave();
-	}
-
-	return NULL;
-		
-}
-
-static void *
-asy_io_write_proc(void *asyp)
-{
-	struct asy *ap = (struct asy *)asyp;
-	int leave;
-	uint8 *data;
-	size_t sz;
-	ssize_t cnt;
-
-	pthread_mutex_lock(&ap->write_lock);
-	pthread_mutex_unlock(&ap->write_lock);
-
-	for (;;) {
-		pthread_mutex_lock(&ap->write_lock);
-		while (!ap->write_exit && !ap->dma.busy)
-			pthread_cond_wait(&ap->write_ready, &ap->write_lock);
-		leave = ap->write_exit;
-		data = ap->dma.data;
-		sz = ap->dma.cnt;
-		pthread_mutex_unlock(&ap->write_lock);
-
-		if (leave)
-			break;
-
-		cnt = write(ap->ttyfd, data, sz);
-		if (cnt <= 0)
-			break;
-
-		interrupt_enter();
-		ap->txchar += cnt;
-		ap->dma.busy = 0;
-		ksignal(&ap->dma, 1);
-		interrupt_leave();
-	}
-
-	return NULL;
 }
 
 static void
@@ -753,7 +391,7 @@ asy_tx(int dummy0, void *asyp, void *dummy1)
 	
 		while(bp != NULL) {
 			/* Send the buffer */
-			asy_write_int(ap, bp->data, bp->cnt);
+			unix_socket_write(ap->socket_entry, bp->data, bp->cnt);
 			/* Now do next buffer on chain */
 			free_mbuf(&bp);
 		}
@@ -766,7 +404,6 @@ asy_shutdown(int dev)
 	struct asy *ap;
 	struct iface *ifp;
 	int i_state;
-	void *dummy;
 
 	if (dev < 0 || dev >= ASY_MAX) {
 		kerrno = kEINVAL;
@@ -780,26 +417,69 @@ asy_shutdown(int dev)
 		return -1;	/* Not allocated */		
 	}
 
-	ifp = ap->iface;
-	ap->iface = NULL;
-
 	i_state = disable();
-	pthread_cancel(ap->read_thread);
+	if (ap->socket_entry != NULL) {
+		unix_socket_shutdown(ap->socket_entry);
+		ap->socket_entry = NULL;
+	}
 	restore(i_state);
 
-	pthread_mutex_lock(&ap->write_lock);
-	ap->write_exit = 1;
-	pthread_cond_signal(&ap->write_ready);
-	pthread_mutex_unlock(&ap->write_lock);
-
-	pthread_join(ap->read_thread, &dummy);
-	pthread_join(ap->write_thread, &dummy);
-
-	close(ap->ttyfd);
-
-	free(ap->fifo.buf);
+	ifp = ap->iface;
+	ap->iface = NULL;
 
 	killproc(&ap->txproc);
 
 	return 0;
+}
+
+int
+asy_tx_dma_busy(int dev)
+{
+	struct asy *ap;
+	if (dev < 0 || dev >= ASY_MAX) {
+		kerrno = kEINVAL;
+		return -1;
+	}
+
+	ap = &Asy[dev];
+	if (ap->socket_entry == NULL) {
+		return 0;
+	}
+
+	return unix_socket_tx_dma_busy(ap->socket_entry);
+}
+
+int
+asy_set_trigchar(int dev, int trigchar)
+{
+	struct asy *ap;
+	if (dev < 0 || dev >= ASY_MAX) {
+		kerrno = kEINVAL;
+		return -1;
+	}
+
+	ap = &Asy[dev];
+	if (ap->socket_entry == NULL) {
+		return 0;
+	}
+
+	unix_socket_set_trigchar(ap->socket_entry, trigchar);
+	return (0);
+}
+
+int
+asy_get_trigchar(int dev)
+{
+	struct asy *ap;
+	if (dev < 0 || dev >= ASY_MAX) {
+		kerrno = kEINVAL;
+		return -1;
+	}
+
+	ap = &Asy[dev];
+	if (ap->socket_entry == NULL) {
+		return 0;
+	}
+
+	return unix_socket_get_trigchar(ap->socket_entry);
 }

--- a/asy_unix.h
+++ b/asy_unix.h
@@ -40,46 +40,13 @@
 #include "iface.h"
 #endif
 
-/* Output pseudo-dma control structure */
-struct dma {
-	uint8 *data;		/* current output pointer */
-	unsigned short cnt;	/* byte count remaining */
-	volatile uint8 busy;	/* transmitter active */
-};
-
-/* Read fifo control structure */
-struct fifo {
-	uint8 *buf;		/* Ring buffer */
-	unsigned bufsize;	/* Size of ring buffer */
-	uint8 *wp;		/* Write pointer */
-	uint8 *rp;		/* Read pointer */
-	volatile unsigned short cnt;	/* count of characters in buffer */
-	unsigned short hiwat;	/* High water mark */
-	long overrun;		/* count of sw fifo buffer overruns */
-};
+#include "unix_socket.h"
 
 /* Asynch controller control block */
 struct asy {
 	struct iface *iface;
-	struct fifo fifo;
-	int trigchar;		/* Fifo trigger character */
 
-	pthread_t read_thread;	/* Device input->fifo thread */
-	pthread_mutex_t read_lock; /* Read thread start gate */
-
-	pthread_t write_thread;	/* DMA->device output thread */
-	pthread_mutex_t write_lock; /* Write thread start gate */
-	pthread_cond_t write_ready; /* Write request is waiting */
-	int write_exit;		/* Exit writing thread */
-	struct dma dma;
-
-	int ttyfd;		/* Device file descriptor */
-	int is_real_tty; 	/* tty vs. socket */     
-	int cts;		/* CTS/RTS handshaking enabled */
-	int speed;		/* current baudrate */
-
-	long rxchar;		/* Received characters */
-	long txchar;		/* Transmitted characters */
+	struct unix_socket_entry *socket_entry;
 
 	struct proc *txproc;
 	struct mbuf *txq;
@@ -89,5 +56,8 @@ extern int Nasy;		/* Actual number of asynch lines */
 extern struct asy Asy[];
 
 int asy_shutdown(int dev);
+extern int asy_tx_dma_busy(int dev);
+extern int asy_set_trigchar(int dev, int trigchar);
+extern int asy_get_trigchar(int dev);
 
 #endif /* ASY_UNIX_H */

--- a/lterm.c
+++ b/lterm.c
@@ -70,8 +70,8 @@ void *p;
 	suspend(ifp->rxproc);
 
 	/* Temporarily change the trigger character */
-	otrigchar = Asy[ifp->dev].trigchar;
-	Asy[ifp->dev].trigchar = -1;
+	otrigchar = asy_get_trigchar(ifp->dev);
+	asy_set_trigchar(ifp->dev, -1);
 
 #ifdef	notdef
 	/* Wait for CD (wired to DTR from local terminal) to go high */

--- a/makefile
+++ b/makefile
@@ -66,7 +66,7 @@ DUMP= 	trace.o enetdump.o \
 	ipdump.o icmpdump.o udpdump.o tcpdump.o ripdump.o
 
 UNIX=	ksubr_unix.o timer_unix.o display_crs.o unix.o dirutil_unix.o \
-	tapdrvr.o tundrvr.o enet.o
+	tapdrvr.o tundrvr.o enet.o unix_socket.o
 
 DSP=	fsk.o mdb.o qpsk.o fft.o r4bf.o fano.o tab.o
 

--- a/ppp.c
+++ b/ppp.c
@@ -330,7 +330,7 @@ struct mbuf **bpp
 	/* No need to send an opening flag if the previous packet is still
 	 * being transmitted.
 	 */
-	if ( Asy[ifp->dev].dma.busy == 0 ) {
+	if (asy_tx_dma_busy(ifp->dev) != 0) {
 		/* Flush out any line garbage */
 		*cp++ = HDLC_FLAG;
 		ppp_p->OutOpenFlag++;

--- a/unix_socket.c
+++ b/unix_socket.c
@@ -1,0 +1,479 @@
+/* UNIX termios serial port NOS driver, for using serial devices hosted on
+ * locally on a UNIX machine. This code was forked from the National
+ * Semiconductor 8250/16550 code written by Phil Karn.
+ *
+ * Copyright 1991 Phil Karn, KA9Q
+ * Copyright 2017 Jeremy Cooper, KE6JJJ.
+ *
+ * Asynchronous devices are traditionally interrupt driven in NOS. But since
+ * this is a UNIX driver there are no interrupts to receive. Instead, we will
+ * simulate interrupt-like behavior with a continuously running I/O thread
+ * which blocks until there is I/O to process.
+ *
+ * The thread will interface with the rest of the NOS code entirely through
+ * the network interface queuing, dequeueing and ksignal() calls and it will
+ * treat the "disable()" and "restore()" interrupt blocking methods as a lock
+ * barrier.
+ */
+#include "top.h"
+
+#ifndef UNIX
+#error "This file should only be built on POSIX/UNIX systems."
+#endif
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "stdio.h"
+#include <errno.h>
+#include "errno.h"
+#include "global.h"
+#include "mbuf.h"
+#include "proc.h"
+#include "devparam.h"
+#include "nosunix.h"
+
+#include "unix_socket.h"
+
+static int
+unix_socket_open_dev(const char *path, int cts, long speed)
+{
+	int ttyfd;
+	struct termios tc;
+
+	if ((ttyfd = open(path, O_RDWR)) == -1) {
+		kprintf("Can't open '%s': %s\n",path,strerror(errno));
+		goto CantOpenDevice;
+	}
+	if (tcgetattr(ttyfd, &tc) != 0) {
+		kprintf("Can't get terminal attributes: %s\n", strerror(errno));
+		goto CantFetchTc;
+	}
+	cfmakeraw(&tc);
+	tc.c_cflag = CS8|CREAD|CLOCAL;
+	if (cts)
+		tc.c_cflag |= CRTSCTS;
+	if (cfsetspeed(&tc, speed) != 0) {
+		kprintf("Can't set baud rate: %s\n", strerror(errno));
+		goto InvalidSpeed;
+	}
+	if (tcsetattr(ttyfd, TCSANOW, &tc) != 0) {
+		kprintf("Can't set terminal attributes: %s\n", strerror(errno));
+		goto CantSetTc;
+	}
+
+	return ttyfd;
+
+CantSetTc:
+InvalidSpeed:
+CantFetchTc:
+	close(ttyfd);
+CantOpenDevice:
+	return -1;
+}
+
+static int
+unix_socket_open_socket(const char *spec)
+{
+	char *hostname, *service;
+	const char *sep;
+	struct addrinfo hints, *res0, *res;
+	int fd, error;
+	
+	sep = (const char *) strrchr(spec, ':');
+	if (sep == NULL) {
+		kprintf("Host specification missing port\n");
+		goto BadChar;
+	}
+
+	service = strdup(sep+1);
+	if (service == NULL) {
+		kprintf("Out of memory.\n");
+		goto BadServiceAlloc;
+	}
+
+	hostname = (char *) malloc(sep - spec + 1);
+	if (hostname == NULL) {
+		kprintf("Out of memory.\n");
+		goto BadHostnameAlloc;
+	}
+
+	memcpy(hostname, spec, sep - spec);
+	hostname[sep - spec] = '\0';
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags =
+		AI_ADDRCONFIG | /* Use IPv4/IPv6 depending on availability */
+		AI_NUMERICSERV; /* Port should be a number */
+	hints.ai_canonname = NULL;
+	hints.ai_next = NULL;
+
+	error = getaddrinfo(hostname, service, &hints, &res0);
+	if (error != 0) {
+		kprintf("getaddrinfo() failure: %s\n", gai_strerror(error));
+		goto GetAddrInfoFailed;
+	}
+
+	/* Try each provided address in turn */
+
+	for (res = res0; res != NULL; res = res->ai_next) {
+		fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+		if (fd == -1) {
+			kprintf("socket() failed.\n");
+			goto SocketFailed;
+		}
+
+		error = connect(fd, res->ai_addr, res->ai_addrlen);
+		if (error >= 0)
+			break;
+
+		close(fd);
+	}
+
+	if (error < 0) {
+		kprintf("connect() failed: %s\n", strerror(errno));
+		goto ConnectFailed;
+	}
+
+	freeaddrinfo(res);
+	free(hostname);
+	free(service);
+
+	return fd;
+
+ConnectFailed:
+	close(fd);
+SocketFailed:
+	freeaddrinfo(res);
+GetAddrInfoFailed:
+	free(hostname);
+BadHostnameAlloc:
+	free(service);
+BadServiceAlloc:
+BadChar:
+	return -1;
+}
+
+static void *
+unix_socket_io_write_proc(void *param)
+{
+	struct unix_socket_entry *us = param;
+	int leave;
+	uint8 *data;
+	size_t sz;
+	ssize_t cnt;
+
+	pthread_mutex_lock(&us->write_lock);
+	pthread_mutex_unlock(&us->write_lock);
+
+	for (;;) {
+		pthread_mutex_lock(&us->write_lock);
+		while (!us->write_exit && !us->dma.busy)
+			pthread_cond_wait(&us->write_ready, &us->write_lock);
+		leave = us->write_exit;
+		data = us->dma.data;
+		sz = us->dma.cnt;
+		pthread_mutex_unlock(&us->write_lock);
+
+		if (leave)
+			break;
+
+		cnt = write(us->ttyfd, data, sz);
+		if (cnt <= 0)
+			break;
+
+		interrupt_enter();
+		us->txchar += cnt;
+		us->dma.busy = 0;
+		ksignal(&us->dma, 1);
+		interrupt_leave();
+	}
+
+	return NULL;
+}
+
+
+static void *
+unix_socket_io_read_proc(void *param)
+{
+	struct unix_socket_entry *us = param;
+	ssize_t cnt, tmp;
+	uint8 buf[1024], *ibp;
+	struct unix_socket_fifo *fp;
+	int sig;
+
+	/* Wait until we are allowed to proceed */
+	pthread_mutex_lock(&us->read_lock);
+
+	/* Go ahead and drop the read lock now that we've started */
+	pthread_mutex_unlock(&us->read_lock);
+
+	fp = &us->fifo;
+
+	for (;;) {
+		cnt = read(us->ttyfd, buf, sizeof(buf));
+		if (cnt == -1)
+			break;
+
+		interrupt_enter();
+
+		/* Search read data for interesting characters if asked */
+		sig = us->trigchar == -1 || memchr(buf, us->trigchar, cnt);
+
+		/* Compute room left in FIFO */
+		tmp = fp->bufsize - fp->cnt;
+		if (cnt > tmp) {
+			/* Not enough room in FIFO */
+			fp->overrun += cnt - tmp;
+			cnt = tmp;
+		}
+
+		/* Update FIFO room */
+		fp->cnt += cnt;
+
+		/* Copy read data into FIFO */
+		ibp = buf;
+		for (tmp = cnt; tmp > 0; tmp--) {
+			*(fp->wp++) = *ibp++;
+			if (fp->wp >= &fp->buf[fp->bufsize])
+				fp->wp = fp->buf;
+		}
+
+		/* Update statistics */
+		us->rxchar += cnt;
+		if (fp->cnt > fp->hiwat)
+			fp->hiwat = fp->cnt;
+
+		/* Wakeup any sleepers if an interesting event has happened */
+		if (sig)
+			ksignal(fp, 1);
+
+		interrupt_leave();
+	}
+
+	return NULL;
+}
+
+
+/*
+ * Create a unix socket handle.
+ *
+ * This is a pointer structure that contains all of
+ * the relevant pieces needed for doing bi-directional
+ * IO to a socket.
+ *
+ * Note: this doesn't yet have a way of signaling to
+ * the owner that a read / write failed or the socket
+ * has closed.
+ */
+struct unix_socket_entry *
+unix_socket_create(const char *path, uint bufsize, int trigchar, long speed,
+    int cts)
+{
+	struct unix_socket_entry *us;
+	int ttyfd;
+	void *dummy;
+
+	us = calloc(1, sizeof(*us));
+
+	if (strchr(path, ':') == NULL) {
+		if ((ttyfd = unix_socket_open_dev(path, cts, speed)) == -1) {
+			goto CantOpenDevice;
+		}
+		us->is_real_tty = 1;
+	} else {
+		if ((ttyfd = unix_socket_open_socket(path)) == -1) {
+			goto CantOpenDevice;
+		}
+		us->is_real_tty = 0;
+	}
+
+	/* Setup receiver FIFO */
+	if ((us->fifo.buf = malloc(bufsize)) == NULL) {
+		kprintf("Can't allocate read ring buffer.\n");
+		goto CantAllocReadBuf;
+	}
+	us->fifo.bufsize = bufsize;
+	us->fifo.wp = us->fifo.buf;
+	us->fifo.rp = us->fifo.buf;
+	us->fifo.cnt = 0;
+	us->fifo.hiwat = 0;
+	us->fifo.overrun = 0;
+
+	/* Setup pthread mutex/cond */
+	if (pthread_mutex_init(&us->read_lock, NULL) != 0) {
+		kprintf("Can't init read lock: %s\n", strerror(errno));
+		goto CantInitReadLock;
+	}
+	if (pthread_mutex_init(&us->write_lock, NULL) != 0) {
+		kprintf("Can't init write lock: %s\n", strerror(errno));
+		goto CantInitWriteLock;
+	}
+	if (pthread_cond_init(&us->write_ready, NULL) != 0) {
+		kprintf("Can't init write cond: %s\n", strerror(errno));
+		goto CantInitWriteCond;
+	}
+
+	/* Grab locks - this will make sure threads don't start too early */
+	pthread_mutex_lock(&us->read_lock);
+	pthread_mutex_lock(&us->write_lock);
+
+	/* Create pthreads */
+	if (pthread_create(&us->read_thread, NULL, unix_socket_io_read_proc, us) != 0){
+		kprintf("Can't start read thread: %s\n", strerror(errno));
+		goto CantStartReadThread;
+	}
+	if (pthread_create(&us->write_thread, NULL, unix_socket_io_write_proc, us) != 0){
+		kprintf("Can't start write thread: %s\n", strerror(errno));
+		goto CantStartWriteThread;
+	}
+
+	/* Initialise local state */
+	us->ttyfd = ttyfd;
+	us->trigchar = trigchar;
+	us->cts = cts;
+	us->speed = speed;
+	us->dma.data = NULL;
+	us->dma.cnt = 0;
+	us->dma.busy = 0;
+	us->write_exit = 0;
+
+	/* Unlock - this starts read/write IO */
+	pthread_mutex_unlock(&us->read_lock);
+	pthread_mutex_unlock(&us->write_lock);
+
+	/* We're good to go! */
+	return us;
+CantStartWriteThread:
+	pthread_cancel(us->read_thread);
+	pthread_join(us->read_thread, &dummy);
+CantStartReadThread:
+	pthread_cond_destroy(&us->write_ready);
+CantInitWriteCond:
+	pthread_mutex_destroy(&us->write_lock);
+CantInitWriteLock:
+	pthread_mutex_destroy(&us->read_lock);
+CantInitReadLock:
+	free(us->fifo.buf);
+	us->fifo.buf = NULL;
+CantAllocReadBuf:
+CantOpenDevice:
+	free(us);
+	return NULL;
+}
+
+/*
+ * Shut down the given socket.  This will signal any
+ * blockers that the socket is going away, close things
+ * and free up state.
+ */
+int
+unix_socket_shutdown(struct unix_socket_entry *us)
+{
+	int i_state;
+	void *dummy;
+
+	i_state = disable();
+	pthread_cancel(us->read_thread);
+	restore(i_state);
+
+	pthread_mutex_lock(&us->write_lock);
+	us->write_exit = 1;
+	pthread_cond_signal(&us->write_ready);
+	pthread_mutex_unlock(&us->write_lock);
+
+	pthread_join(us->read_thread, &dummy);
+	pthread_join(us->write_thread, &dummy);
+
+	close(us->ttyfd);
+
+	free(us->fifo.buf);
+	return 0;
+}
+
+/*
+ * Blocking read.
+ */
+int
+unix_socket_read(struct unix_socket_entry *us, void *buf, unsigned short cnt)
+{
+	int tmp, i_state;
+	struct unix_socket_fifo *fp;
+	uint8 *obp;
+
+	if (cnt == 0)
+		return 0;
+
+	fp = &us->fifo;
+
+	for (;;) {
+		i_state = disable();
+		tmp = fp->cnt;
+		if (tmp != 0)
+			break;
+		restore(i_state);
+		if ((kerrno = kwait(fp)) != 0)
+			return -1;
+	}
+
+	obp = (uint8 *)buf;
+
+	if (cnt > tmp)
+		cnt = tmp;      /* Limit to data on hand */
+	fp->cnt -= cnt;
+	for (tmp = cnt; tmp > 0; tmp--) {
+		*obp++ = *fp->rp++;
+		if (fp->rp >= &fp->buf[fp->bufsize])
+			fp->rp = fp->buf;
+	}
+	restore(i_state);
+
+	return cnt;
+}
+
+/*
+ * Blocking write.
+ */
+int
+unix_socket_write(struct unix_socket_entry *us, const void *buf, unsigned short cnt)
+{
+	int tmp, i_state;
+	struct unix_socket_dma *dp;
+
+	dp = &us->dma;
+
+	i_state = disable();
+	if(dp->busy) {
+		restore(i_state);
+		return -1;      /* Already busy in another process */
+	}
+
+	pthread_mutex_lock(&us->write_lock);
+
+	dp->data = (uint8 *)buf;
+	dp->cnt = cnt;
+	dp->busy = 1;
+
+	pthread_cond_signal(&us->write_ready);
+	pthread_mutex_unlock(&us->write_lock);
+	restore(i_state);
+
+	/* Wait for completion */
+	for(;;){
+		i_state = disable();
+		tmp = dp->busy;
+		restore(i_state);
+		if(tmp == 0)
+			break;
+		kwait(&us->dma);
+	}
+	return cnt;
+}

--- a/unix_socket.c
+++ b/unix_socket.c
@@ -582,3 +582,11 @@ unix_socket_modem_bits(struct unix_socket_entry *us, int setbits,
 	return 0;
 }
 
+int
+unix_socket_is_real_tty(struct unix_socket_entry *us)
+{
+	if (us == NULL) {
+		return 0;
+	}
+	return us->is_real_tty;
+}

--- a/unix_socket.c
+++ b/unix_socket.c
@@ -477,3 +477,22 @@ unix_socket_write(struct unix_socket_entry *us, const void *buf, unsigned short 
 	}
 	return cnt;
 }
+
+int
+unix_socket_tx_dma_busy(struct unix_socket_entry *us)
+{
+	return (us->dma.busy != 0);
+}
+
+int
+unix_socket_get_trigchar(struct unix_socket_entry *us)
+{
+	return (us->trigchar);
+}
+
+int
+unix_socket_set_trigchar(struct unix_socket_entry *us, int trigchar)
+{
+	us->trigchar = trigchar;
+	return 0;
+}

--- a/unix_socket.c
+++ b/unix_socket.c
@@ -590,3 +590,35 @@ unix_socket_is_real_tty(struct unix_socket_entry *us)
 	}
 	return us->is_real_tty;
 }
+
+int
+unix_socket_flowcontrol_cts(struct unix_socket_entry *us)
+{
+	if (us == NULL) {
+		return 0;
+	}
+	return us->cts;
+}
+
+int
+unix_socket_get_stats(struct unix_socket_entry *us, struct unix_socket_stats *stats)
+{
+	if (us == NULL) {
+		return -1;
+	}
+	stats->rxchar = us->rxchar;
+	stats->txchar = us->txchar;
+	stats->fifo_overrun = us->fifo.overrun;
+	stats->fifo_hiwat = us->fifo.hiwat;
+	us->fifo.hiwat = 0;
+	return 0;
+}
+
+long
+unix_socket_get_speed(struct unix_socket_entry *us)
+{
+	if (us == NULL) {
+		return -1;
+	}
+	return us->speed;
+}

--- a/unix_socket.h
+++ b/unix_socket.h
@@ -1,0 +1,87 @@
+/* UNIX termios serial port NOS driver, for using serial devices hosted on
+ * locally on a UNIX machine. This code was forked from the National
+ * Semiconductor 8250/16550 code written by Phil Karn.
+ *
+ * Copyright 1991 Phil Karn, KA9Q
+ * Copyright 2017 Jeremy Cooper, KE6JJJ.
+ *
+ * Asynchronous devices are traditionally interrupt driven in NOS. But since
+ * this is a UNIX driver there are no interrupts to receive. Instead, we will
+ * simulate interrupt-like behavior with a continuously running I/O thread
+ * which uses the select() call to block until there is I/O to process.
+ *
+ * The thread will interface with the rest of the NOS code entirely through
+ * the network interface queuing, dequeueing and ksignal() calls and it will
+ * treat the "disable()" and "restore()" interrupt blocking methods as a lock
+ * barrier.
+ *
+ * This header defines the private interfaces shared between the
+ * UNIX-dependent setup code and the I/O threads for async interfaces.
+ */
+#ifndef KA9Q_UNIX_SOCKET_H
+#define KA9Q_UNIX_SOCKET_H
+
+#include "top.h"
+
+#include <pthread.h>
+
+#ifndef	_MBUF_H
+#include "mbuf.h"
+#endif
+
+#ifndef _PROC_H
+#include "proc.h"
+#endif
+
+/* Output pseudo-dma control structure */
+struct unix_socket_dma {
+	uint8 *data;		/* current output pointer */
+	unsigned short cnt;	/* byte count remaining */
+	volatile uint8 busy;	/* transmitter active */
+};
+
+/* Read fifo control structure */
+struct unix_socket_fifo {
+	uint8 *buf;		/* Ring buffer */
+	unsigned bufsize;	/* Size of ring buffer */
+	uint8 *wp;		/* Write pointer */
+	uint8 *rp;		/* Read pointer */
+	volatile unsigned short cnt;	/* count of characters in buffer */
+	unsigned short hiwat;	/* High water mark */
+	long overrun;		/* count of sw fifo buffer overruns */
+};
+
+/* Unix socket control block */
+struct unix_socket_entry {
+
+	pthread_t read_thread;	/* Device input->fifo thread */
+	pthread_mutex_t read_lock; /* Read thread start gate */
+
+	pthread_t write_thread;	/* DMA->device output thread */
+	pthread_mutex_t write_lock; /* Write thread start gate */
+	pthread_cond_t write_ready; /* Write request is waiting */
+	int write_exit;		/* Exit writing thread */
+	int trigchar;
+
+	struct unix_socket_dma dma;
+	struct unix_socket_fifo fifo;
+
+	int ttyfd;		/* Device file descriptor */
+	int is_real_tty; 	/* tty vs. socket */
+
+	int cts;		/* CTS/RTS handshaking enabled */
+	int speed;		/* current baudrate */
+
+	long rxchar;		/* Received characters */
+	long txchar;		/* Transmitted characters */
+};
+
+extern	struct unix_socket_entry * unix_socket_create(const char *path,
+	    uint bufsize, int trigchar, long speed, int cts);
+extern	int unix_socket_shutdown(struct unix_socket_entry *us);
+extern	int unix_socket_read(struct unix_socket_entry *us, void *buf,
+	    unsigned short cnt);
+extern	int unix_socket_write(struct unix_socket_entry *us, const void *buf,
+	    unsigned short cnt);
+
+#endif /* KA9Q_UNIX_SOCKET_H */

--- a/unix_socket.h
+++ b/unix_socket.h
@@ -84,4 +84,8 @@ extern	int unix_socket_read(struct unix_socket_entry *us, void *buf,
 extern	int unix_socket_write(struct unix_socket_entry *us, const void *buf,
 	    unsigned short cnt);
 
+extern	int unix_socket_tx_dma_busy(struct unix_socket_entry *us);
+extern	int unix_socket_get_trigchar(struct unix_socket_entry *us);
+extern	int unix_socket_set_trigchar(struct unix_socket_entry *us, int trigchar);
+
 #endif /* KA9Q_UNIX_SOCKET_H */

--- a/unix_socket.h
+++ b/unix_socket.h
@@ -33,6 +33,13 @@
 #include "proc.h"
 #endif
 
+struct unix_socket_stats {
+	long rxchar;
+	long txchar;
+	long fifo_overrun;
+	long fifo_hiwat;
+};
+
 /* Output pseudo-dma control structure */
 struct unix_socket_dma {
 	uint8 *data;		/* current output pointer */
@@ -94,5 +101,9 @@ extern	int32 unix_socket_ioctl(struct unix_socket_entry *us, int cmd,
 extern	int unix_socket_modem_bits(struct unix_socket_entry *us, int setbits,
 	    int clearbits, int *readbits);
 extern	int unix_socket_is_real_tty(struct unix_socket_entry *us);
+extern	int unix_socket_flowcontrol_cts(struct unix_socket_entry *us);
+extern	int unix_socket_get_stats(struct unix_socket_entry *us,
+	    struct unix_socket_stats *stats);
+extern	long unix_socket_get_speed(struct unix_socket_entry *us);
 
 #endif /* KA9Q_UNIX_SOCKET_H */

--- a/unix_socket.h
+++ b/unix_socket.h
@@ -93,5 +93,6 @@ extern	int32 unix_socket_ioctl(struct unix_socket_entry *us, int cmd,
 	    int set, int32 val);
 extern	int unix_socket_modem_bits(struct unix_socket_entry *us, int setbits,
 	    int clearbits, int *readbits);
+extern	int unix_socket_is_real_tty(struct unix_socket_entry *us);
 
 #endif /* KA9Q_UNIX_SOCKET_H */

--- a/unix_socket.h
+++ b/unix_socket.h
@@ -88,4 +88,10 @@ extern	int unix_socket_tx_dma_busy(struct unix_socket_entry *us);
 extern	int unix_socket_get_trigchar(struct unix_socket_entry *us);
 extern	int unix_socket_set_trigchar(struct unix_socket_entry *us, int trigchar);
 
+extern	int unix_socket_set_line_speed(struct unix_socket_entry *us, long bps);
+extern	int32 unix_socket_ioctl(struct unix_socket_entry *us, int cmd,
+	    int set, int32 val);
+extern	int unix_socket_modem_bits(struct unix_socket_entry *us, int setbits,
+	    int clearbits, int *readbits);
+
 #endif /* KA9Q_UNIX_SOCKET_H */


### PR DESCRIPTION
This patchset abstracts out the unix socket handling from asy_unix.c into a new file/API so it can eventually be reused elsewhere. It also makes sure there are no direct references to the Asy[] array contents from outside of asy.c / asy_unix.c.

It doesn't yet implement all of the methods (notably no accept, async connect, datagram methods) but they shouldn't be difficult to add.

I have some vague hopes to add local socket types to the internal socket representation so we can start doing things like incoming telnet services, axudp, etc directly with local sockets rather than requiring a tunnel interface to the local device networking stack. But hey, I'll see how this goes!