### PR TITLE
20191018 add unproto monitor

### DIFF
--- a/cmd/ax25/ax25cmd.c
+++ b/cmd/ax25/ax25cmd.c
@@ -643,7 +643,7 @@ unproto_recv(struct unproto_session *us)
 	/* Process input on the connection */
 	from_len = sizeof(from_addr);
 	while ((read_len = krecvfrom(us->s, buf, 1024, 0, &from_addr, &from_len)) > 0) {
-		kprintf("received %d bytes", read_len);
+		kprintf("received %d bytes from %s\n", read_len ,psocket(&from_addr));
 		kfflush(kstdout);
 		from_len = sizeof(from_addr);
 	}

--- a/cmd/ax25/ax25cmd.c
+++ b/cmd/ax25/ax25cmd.c
@@ -634,8 +634,8 @@ unproto_output(int unused, void *tn1, void *p)
 	sp = us->sp;
 
 	/* Send whatever's typed on the terminal */
-	while ((s = kfgets(buf, 1023, kstdin)) != NULL) {
-		if (kfeof(kstdin)) {
+	while ((s = kfgets(buf, 1023, sp->input)) != NULL) {
+		if (kfeof(sp->input)) {
 			kprintf("%s: Hit EOF on stdin\n", __func__);
 			break;
 		}

--- a/cmd/ax25/ax25cmd.c
+++ b/cmd/ax25/ax25cmd.c
@@ -633,7 +633,7 @@ unproto_output(int unused, void *tn1, void *p)
 	us = tn1;
 	sp = us->sp;
 
-        /* Send whatever's typed on the terminal */
+	/* Send whatever's typed on the terminal */
 	while ((s = kfgets(buf, 1023, kstdin)) != NULL) {
 		if (kfeof(kstdin)) {
 			kprintf("%s: Hit EOF on stdin\n", __func__);
@@ -694,28 +694,28 @@ unproto_recv(struct unproto_session *us)
 	freesession(&sp);
 }
 
-int
+static int
 unproto_connect(struct session *sp, struct ksockaddr *fsocket,int len)
 {
-        struct unproto_session us;
+	struct unproto_session us;
 
-        memset(&us,0,sizeof(us));
-        us.sp = sp;	/* Upward pointer */
-        sp->cb.p = &us;		/* Downward pointer */
+	memset(&us,0,sizeof(us));
+	us.sp = sp;	/* Upward pointer */
+	sp->cb.p = &us;		/* Downward pointer */
 
-        kprintf("Trying %s...\n",psocket(fsocket));
-        if(kconnect(sp->network_fd, fsocket, len) == -1){
-                kperror("connect failed");
-                keywait(NULL,1);
+	kprintf("Trying %s...\n",psocket(fsocket));
+	if(kconnect(sp->network_fd, fsocket, len) == -1){
+		kperror("connect failed");
+		keywait(NULL,1);
 		kclose(sp->network_fd);
 		sp->network_fd = -1;
-                freesession(&sp);
-                return 1;
-        }
-        kprintf("Connected to %s\n", psocket(fsocket));
-        sp->inproc = NULL;      /* No longer respond to ^C */   
-        unproto_recv(&us);
-        return 0;
+		freesession(&sp);
+		return 1;
+	}
+	kprintf("Connected to %s\n", psocket(fsocket));
+	sp->inproc = NULL;      /* No longer respond to ^C */   
+	unproto_recv(&us);
+	return 0;
 }
 
 
@@ -772,5 +772,6 @@ do_unproto_connect(int argc,char *argv[], void *p)
 	}
 	sp->network_fd = s;
 	kprintf("Socket creation ok! (%d)\n", s);
-	return unproto_connect(sp, (struct ksockaddr *)&fsocket, sizeof(struct ksockaddr_ax));
+	return unproto_connect(sp, (struct ksockaddr *)&fsocket,
+	    sizeof(struct ksockaddr_ax));
 }

--- a/cmd/ax25/ax25cmd.c
+++ b/cmd/ax25/ax25cmd.c
@@ -714,6 +714,7 @@ unproto_connect(struct session *sp, struct ksockaddr *fsocket,int len)
 		return 1;
 	}
 	kprintf("Connected to %s\n", psocket(fsocket));
+	CLEARSIG(kEABORT);
 	sp->inproc = NULL;      /* No longer respond to ^C */   
 	unproto_recv(&us);
 	return 0;

--- a/cmd/sockcmd/sockcmd.c
+++ b/cmd/sockcmd/sockcmd.c
@@ -57,8 +57,9 @@ void *p;
 	}
 	sp = up->sp;
 	kprintf("%s %p\n",Socktypes[up->type],up->cb.p);
-	if(up->cb.p == NULL)
+	if(! so_is_connected(up)) {
 		return 0;
+	}
 	if(sp->status != NULL)
 		(*sp->status)(up);
 	return 0;	

--- a/commands.h
+++ b/commands.h
@@ -22,6 +22,7 @@ int doax25(int argc,char *argv[],void *p);
 int doaxheard(int argc,char *argv[],void *p);
 int doaxdest(int argc,char *argv[],void *p);
 int doconnect(int argc,char *argv[],void *p);
+int do_unproto_connect(int argc,char *argv[],void *p);
 
 /* In bootp.c */
 int dobootp(int argc,char *argv[],void *p);

--- a/config.c
+++ b/config.c
@@ -134,7 +134,8 @@ struct cmds Cmds[] = {
 #endif
 /* This one is out of alpabetical order to allow abbreviation to "c" */
 #ifdef	AX25
-	{ "connect",	doconnect,	1024, 3, "connect <interface> <callsign>" },
+	{ "connect",	doconnect,	1024, 3, "connect <interface> <callsign> [<digipeater path>]" },
+	{ "unproto_connect",	do_unproto_connect,	1024, 3, "connect <interface> <callsign> [<digipeater path>]" },
 #endif
 #if	!defined(AMIGA)
 	{ "cd",		docd,		0, 0, NULL },

--- a/config.c
+++ b/config.c
@@ -135,7 +135,7 @@ struct cmds Cmds[] = {
 /* This one is out of alpabetical order to allow abbreviation to "c" */
 #ifdef	AX25
 	{ "connect",	doconnect,	1024, 3, "connect <interface> <callsign> [<digipeater path>]" },
-	{ "unproto_connect",	do_unproto_connect,	1024, 3, "connect <interface> <callsign> [<digipeater path>]" },
+	{ "unproto_connect",	do_unproto_connect,	1024, 3, "unproto_connect <interface> <callsign> [<digipeater path>]" },
 #endif
 #if	!defined(AMIGA)
 	{ "cd",		docd,		0, 0, NULL },

--- a/core/proc.h
+++ b/core/proc.h
@@ -93,6 +93,7 @@ extern struct ksig Ksig;
  */
 #define	SETSIG(val)	(Curproc->flags.sset=1,\
 	Curproc->signo = (val),setjmp(Curproc->sig))
+#define	CLEARSIG(val)	(Curproc->flags.sset=0)
 
 /* In  kernel.c: */
 void alert(struct proc *pp,int val);

--- a/core/session.c
+++ b/core/session.c
@@ -160,7 +160,6 @@ char *argv[];
 void *p;
 {
 	struct session *sp;
-	int ret;
 
 	sp = (struct session *)p;
 	if(argc > 1)
@@ -172,19 +171,9 @@ void *p;
 	}
 
 	if (sp->network_fd != -1) {
-		ret = kshutdown(sp->network_fd, 1);
-		if (ret != 0) {
-			kprintf("%s: failed kshutdown; err=%s\n",
-			    __func__,
-			    ksys_errlist[kerrno]);
-		}
+		kshutdown(sp->network_fd, 1);
 	}
-	ret = kshutdown(kfileno(sp->network),1);
-	if (ret != 0) {
-		kprintf("%s: failed kshutdown; err=%s\n",
-		    __func__,
-		    ksys_errlist[kerrno]);
-	}
+	kshutdown(kfileno(sp->network),1);
 
 	return 0;
 }

--- a/core/session.c
+++ b/core/session.c
@@ -160,6 +160,7 @@ char *argv[];
 void *p;
 {
 	struct session *sp;
+	int ret;
 
 	sp = (struct session *)p;
 	if(argc > 1)
@@ -171,9 +172,20 @@ void *p;
 	}
 
 	if (sp->network_fd != -1) {
-		kshutdown(sp->network_fd, 1);
+		ret = kshutdown(sp->network_fd, 1);
+		if (ret != 0) {
+			kprintf("%s: failed kshutdown; err=%s\n",
+			    __func__,
+			    ksys_errlist[kerrno]);
+		}
 	}
-	kshutdown(kfileno(sp->network),1);
+	ret = kshutdown(kfileno(sp->network),1);
+	if (ret != 0) {
+		kprintf("%s: failed kshutdown; err=%s\n",
+		    __func__,
+		    ksys_errlist[kerrno]);
+	}
+
 	return 0;
 }
 int

--- a/core/session.c
+++ b/core/session.c
@@ -100,6 +100,12 @@ void *p;
 			k = kgetpeername(s,&fsocket,&i);
 			t += socklen(s,1);
 			cp = sockstate(s);
+		} else if (sp->network_fd != -1) {
+			s = sp->network_fd;
+			i = SOCKSIZE;
+			k = kgetpeername(sp->network_fd, &fsocket, &i);
+			t += socklen(sp->network_fd, 1);
+			cp = sockstate(sp->network_fd);
 		} else {
 			k = s = -1;
 			t = 0;
@@ -163,6 +169,10 @@ void *p;
 		kprintf(Badsess);
 		return -1;
 	}
+
+	if (sp->network_fd != -1) {
+		kshutdown(sp->network_fd, 1);
+	}
 	kshutdown(kfileno(sp->network),1);
 	return 0;
 }
@@ -184,6 +194,9 @@ void *p;
 	}
 	/* Unwedge anyone waiting for a domain resolution, etc */
 	alert(sp->proc,kEABORT);
+	if (sp->network_fd != -1) {
+		kshutdown(sp->network_fd, 2);
+	}
 	kshutdown(kfileno(sp->network),2);
 	if(sp->type == FTP)
 		kshutdown(kfileno(sp->cb.ftp->data),2);
@@ -204,6 +217,9 @@ void *p;
 	if(sp == NULL){
 		kprintf(Badsess);
 		return -1;
+	}
+	if (sp->network_fd != -1) {
+		sockkick(sp->network_fd);
 	}
 	sockkick(kfileno(sp->network));
 	if(sp->type == FTP)
@@ -239,6 +255,7 @@ int makecur;
 	sp = Sessions[i] = (struct session *)calloc(1,sizeof(struct session));
 	sp->index = i;
 	sp->type = type;
+	sp->network_fd = -1;
 	if(name != NULL)
 		sp->name = strdup(name);
 	sp->proc = Curproc;
@@ -285,6 +302,10 @@ struct session **spp;
 	free(sp->ttystate.line);
 	if(sp->network != NULL)
 		kfclose(sp->network);
+	if(sp->network_fd != -1) {
+		kclose(sp->network_fd);
+		sp->network_fd = -1;
+	}
 
 	if(sp->record != NULL)
 		kfclose(sp->record);

--- a/core/session.h
+++ b/core/session.h
@@ -47,6 +47,7 @@ struct session {
 	struct proc *proc;	/* Primary session process (e.g., tn recv) */
 	struct proc *proc1;	/* Secondary session process (e.g., tn xmit) */
 	struct proc *proc2;	/* Tertiary session process (e.g., upload) */
+	int network_fd;		/* Alternative - primary network socket, when not kFILE */
 	kFILE *network;		/* Primary network socket (control for FTP) */
 	kFILE *record;		/* Receive record file */
 	kFILE *upload;		/* Send file */

--- a/core/socket.c
+++ b/core/socket.c
@@ -223,7 +223,7 @@ int backlog	/* 0 for a single connection, !=0 for multiple connections */
 		kerrno = kEBADF;
 		return -1;
 	}
-	if(up->cb.p != NULL){
+	if(so_is_connected(up)) {
 		kerrno = kEISCONN;
 		return -1;
 	}
@@ -287,7 +287,7 @@ int *peernamelen	/* Length of peer name */
 		kerrno = kEBADF;
 		return -1;
 	}
-	if(up->cb.p == NULL){
+	if(! so_is_connected(up)) {
 		kerrno = kEOPNOTSUPP;
 		return -1;
 	}
@@ -298,7 +298,7 @@ int *peernamelen	/* Length of peer name */
 		return -1;
 	}
 	/* Wait for the state-change upcall routine to signal us */
-	while(up->cb.p != NULL && up->rdysock == -1){
+	while(so_is_connected(up) && up->rdysock == -1){
 		if(up->noblock){
 			kerrno = kEWOULDBLOCK;
 			return -1;
@@ -306,7 +306,7 @@ int *peernamelen	/* Length of peer name */
 			return -1;
 		}
 	}
-	if(up->cb.p == NULL){
+	if(! so_is_connected(up)) {
 		/* Blown away */
 		kerrno = kEBADF;
 		return -1;
@@ -461,7 +461,7 @@ int rtx		/* 0 = receive queue, 1 = transmit queue */
 		kerrno = kEBADF;
 		return -1;
 	}
-	if(up->cb.p == NULL){
+	if(! so_is_connected(up)) {
 		kerrno = kENOTCONN;
 		return -1;
 	}
@@ -536,11 +536,13 @@ int how		/* (see above) */
 		kerrno = kEBADF;
 		return -1;
 	}
-	if(up->cb.p == NULL){
+
+	if(! so_is_connected(up)) {
 		kerrno = kENOTCONN;
 		return -1;
 	}
 	sp = up->sp;
+
 	/* Just close the socket if special shutdown routine not present */
 	if(sp->shut == NULL){
 		close_s(s);

--- a/core/sockutil.c
+++ b/core/sockutil.c
@@ -57,7 +57,7 @@ int s;		/* Socket index */
 		kerrno = kEBADF;
 		return NULL;
 	}
-	if(up->cb.p == NULL){
+	if(! so_is_connected(up)) {
 		kerrno = kENOTCONN;
 		return NULL;
 	}

--- a/core/usock.h
+++ b/core/usock.h
@@ -8,6 +8,8 @@
 #include "net/inet/ip.h"
 #include "net/inet/tcp.h"
 #include "net/inet/udp.h"
+#include "net/ax25/lapb.h"
+#include "net/ax25/axui.h"
 
 struct loc {
 	struct usock *peer;
@@ -55,6 +57,7 @@ union cb {
 	struct raw_nr *rnr;
 	struct nr4cb *nr4;
 	struct loc *local;
+	struct ax25ui_cb *ax25ui;
 	void *p;
 };
 

--- a/core/usock.h
+++ b/core/usock.h
@@ -46,6 +46,7 @@ struct socklink {
 	char *eol;
 };
 extern struct socklink Socklink[];
+
 union cb {
 	struct tcb *tcb;
 	struct ax25_cb *ax25;
@@ -56,6 +57,7 @@ union cb {
 	struct loc *local;
 	void *p;
 };
+
 /* User sockets */
 struct usock {
 	unsigned index;
@@ -94,6 +96,18 @@ extern unsigned Nsock;
 struct usock *itop(int s);
 void st_garbage(int red);
 int so_ip_autobind(struct usock *up);
+
+/*
+ * Return 1 if the socket is connected, 0 otherwise.
+ */
+static inline int
+so_is_connected(struct usock *up)
+{
+  if (up->cb.p == NULL) {
+    return 0;
+  }
+  return 1;
+}
 
 /* In axsocket.c: */
 int so_ax_sock(struct usock *up,int protocol);

--- a/net/ax25/axui.h
+++ b/net/ax25/axui.h
@@ -1,0 +1,19 @@
+#ifndef	_KA9Q_AX25UI_H
+#define	_KA9Q_AX25UI_H
+
+#include "global.h"
+#include "net/core/mbuf.h"
+#include "net/core/iface.h"
+#include "core/timer.h"
+
+#include "net/ax25/ax25.h"
+
+/*
+ * For now this is just a placeholder until a full
+ * ax25 ui socket table and mux/demux is written.
+ */
+struct ax25ui_cb {
+  int unused;
+};
+
+#endif /* _KA9Q_AX25UI_H */

--- a/net/tap/tapdrvr.c
+++ b/net/tap/tapdrvr.c
@@ -1,7 +1,7 @@
 /* Driver for BSD user-mode "TAP" Ethernet devices.
  * Copyright 2018 Jeremy Cooper.
  */
-#include "../../top.h"
+#include "top.h"
 
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -12,20 +12,20 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include "../../stdio.h"
-#include "../../global.h"
-#include "../../proc.h"
-#include "../../mbuf.h"
-#include "../../iface.h"
-#include "../../trace.h"
-#include "../../config.h"
+#include "lib/std/stdio.h"
+#include "global.h"
+#include "core/proc.h"
+#include "net/core/mbuf.h"
+#include "net/core/iface.h"
+#include "core/trace.h"
+#include "config.h"
 
-#include "../enet/enet.h"
-#include "../arp/arp.h"
-#include "../../lib/inet/netuser.h"
-#include "../../unix/nosunix.h"
+#include "net/enet/enet.h"
+#include "net/arp/arp.h"
+#include "lib/inet/netuser.h"
+#include "unix/nosunix.h"
 
-#include "tapdrvr.h"
+#include "net/tap/tapdrvr.h"
 
 /* Maximum number of fragments to tolerate in an outgoing packet */
 #define MAX_FRAGS	10

--- a/net/tun/tundrvr.c
+++ b/net/tun/tundrvr.c
@@ -1,7 +1,7 @@
 /* Driver for BSD user-mode "TUN" packet tunnel devices.
  * Copyright 2018 Jeremy Cooper.
  */
-#include "../../top.h"
+#include "top.h"
 
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -12,17 +12,17 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#include "../../stdio.h"
-#include "../../global.h"
-#include "../../proc.h"
-#include "../../mbuf.h"
-#include "../../iface.h"
-#include "../../trace.h"
-#include "../../config.h"
+#include "lib/std/stdio.h"
+#include "global.h"
+#include "core/proc.h"
+#include "net/core/mbuf.h"
+#include "net/core/iface.h"
+#include "core/trace.h"
+#include "config.h"
 
-#include "../../lib/inet/netuser.h"
-#include "../../unix/nosunix.h"
-#include "tundrvr.h"
+#include "lib/inet/netuser.h"
+#include "unix/nosunix.h"
+#include "net/tun/tundrvr.h"
 
 /* Maximum number of fragments to tolerate in an outgoing packet */
 #define MAX_FRAGS	10


### PR DESCRIPTION
This adds a simple unproto ax25 monitor that can be used for unproto chat sessions (ie, what packet radio nets tend to use.)

* add a new network_fd socket that isn't a stream - it's a socket! - so it can be used with datagram sockets
* add the ability to CLEAR a signal, rather than just set it
* add the new command
* refactor the is connected check to so_is_connected() in preparation for some other socket work.